### PR TITLE
Optimize and align all 3 benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .mypy_cache
-zig-cache
+.zig-cache
 zig-out

--- a/c/main.c
+++ b/c/main.c
@@ -1,38 +1,35 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
-#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
 
-int sieve_of_eratosthenes(int n)
-{
-    bool *is_prime = (bool *)malloc((n + 1) * sizeof(bool));
+int sieve_of_eratosthenes(int n) {
+    if (n < 2) return 0;
+    if (n == 2) return 1;
 
-    for (int i = 2; i <= n; i++)
-    {
-        is_prime[i] = true;
-    }
+    size_t odd_count = (n - 1) / 2;
+    size_t byte_size = (odd_count + 7) / 8;
+    uint8_t *bits = malloc(byte_size);
+    
+    memset(bits, 0xFF, byte_size);
 
-    for (int i = 2; i <= sqrt(n); i++)
-    {
-        if (is_prime[i])
-        {
-            for (int j = i * i; j <= n; j += i)
-            {
-                is_prime[j] = false;
+    for (size_t i = 0; 2 * i + 3 <= n; i++) {
+        if (bits[i/8] & (1 << (i%8))) {
+            size_t prime = 2 * i + 3;
+            if (prime * prime <= n) {
+                for (size_t j = (prime * prime - 3) / 2; j < odd_count; j += prime) {
+                    bits[j/8] &= ~(1 << (j%8));
+                }
             }
         }
     }
 
-    int total = 0;
-    for (int i = 2; i <= n; i++)
-    {
-        if (is_prime[i])
-        {
-            total++;
-        }
+    int total = 1;
+    for (size_t i = 0; i < odd_count; i++) {
+        if (bits[i/8] & (1 << (i%8))) total++;
     }
 
-    free(is_prime);
+    free(bits);
     return total;
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,24 +1,36 @@
 fn sieve_of_eratosthenes(n: usize) -> usize {
-    let mut is_prime = vec![true; n + 1];
-    let mut total = 0;
-    is_prime[0] = false;
-    is_prime[1] = false;
+    if n < 2 { return 0; }
+    if n == 2 { return 1; }
 
-    for i in 2..=(n as f64).sqrt() as usize {
-        if is_prime[i] {
-            for j in ((i * i)..=n).step_by(i) {
-                is_prime[j] = false;
+    let odd_count = (n - 1) >> 1;
+    let bytes = (odd_count + 7) >> 3;
+    let mut bits = vec![0xFF_u8; bytes];
+
+    let mut i = 0;
+    while 2 * i + 3 <= n {
+        if (bits[i >> 3] & (1 << (i & 7))) != 0 {
+            let prime = 2 * i + 3;
+            if prime * prime <= n {
+                let mut j = (prime * prime - 3) >> 1;
+                while j < odd_count {
+                    bits[j >> 3] &= !(1 << (j & 7));
+                    j += prime;
+                }
             }
         }
+        i += 1;
     }
 
-    for i in 2..=n {
-        if is_prime[i] {
-            total += 1;
+    let mut count = 1;
+    let mut pos = 0;
+    while pos < odd_count {
+        if (bits[pos >> 3] & (1 << (pos & 7))) != 0 {
+            count += 1;
         }
+        pos += 1;
     }
 
-    total
+    count
 }
 
 fn main() {
@@ -26,5 +38,5 @@ fn main() {
     let n = args[1].parse::<usize>().unwrap();
 
     let primes = sieve_of_eratosthenes(n);
-    println!("Primes up to {} are: {}", n, primes);
+    println!("There are {} primes between 2 and {}", primes, n);
 }


### PR DESCRIPTION
The current benchmarks don't really play to the strengths of each language. I've somewhat aligned them all and optimized a bit but made sure the logic/process is essentially the same in them all and ofc retained the basic algorithm we started with. Now the results are much closer and no weird double ram use on the zig. The results still show the same pecking order though.

This was tested with clang 19 and cargo 1.83.0 and zig 0.14.0 nightly:

![image](https://github.com/user-attachments/assets/907f5070-93d5-47da-b620-e7b24ff05c75)

